### PR TITLE
Remove deprecated connection options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ class MongoOplogReader extends EventEmitter {
     this.masterDuration = options.masterDuration || defaults.masterDuration;
     this.healthcheckDuration = options.healthcheckDuration || defaults.healthcheckDuration;
     this.mongoConnectOptions = options.mongoConnectOptions || defaultMongoConnectOptions;
+    this.startAt = options.startAt;
     this.workerId = `${Math.random()}`.substr(2);
     this.workerRegistrationKey = `${this.keyPrefix}:workerIds`;
     this.assignmentsByConnStr = {};
@@ -341,7 +342,8 @@ class MongoOplogReader extends EventEmitter {
       debug('replSet info: %o', info);
       const replSetName = info.setName;
       const memberName = info.me;
-      return this.getLastOpTimestamp(replSetName).then(ts => {
+      const startTs = this.startAt ? Promise.resolve(this.startAt) : this.getLastOpTimestamp(replSetName);
+      return startTs.then(ts => {
         debug(`${replSetName} ts: %s`, ts);
         const opts = { since: ts || 1 }; // start where we left off, otherwise from the beginning
         const oplog = MongoOplog(db, opts);

--- a/src/index.js
+++ b/src/index.js
@@ -30,15 +30,11 @@ const defaults = {
 };
 
 const defaultMongoConnectOptions = {
-  server: {
-    poolSize: 100,
-    auto_reconnect: true,
-    socketOptions: {
-      keepAlive: 5000,
-      connectTimeoutMS: 30000,
-      socketTimeout: 30000
-    }
-  }
+  poolSize: 100,
+  autoReconnect: true,
+  keepAlive: 5000,
+  connectTimeoutMS: 30000,
+  socketTimeoutMS: 30000
 };
 
 const opCode = {


### PR DESCRIPTION
Fixes this warning on startup:

```
the server/replset/mongos options are deprecated, all their options are supported at the top level of the options object [poolSize,ssl,sslValidate,sslCA,sslCert,ciphers,ecdhCurve,sslKey,sslPass,sslCRL,autoReconnect,noDelay,keepAlive,connectTimeoutMS,family,socketTimeoutMS,reconnectTries,reconnectInterval,ha,haInterval,replicaSet,secondaryAcceptableLatencyMS,acceptableLatencyMS,connectWithNoPrimary,authSource,w,wtimeout,j,forceServerObjectId,serializeFunctions,ignoreUndefined,raw,bufferMaxEntries,readPreference,pkFactory,promiseLibrary,readConcern,maxStalenessSeconds,loggerLevel,logger,promoteValues,promoteBuffers,promoteLongs,domainsEnabled,keepAliveInitialDelay,checkServerIdentity,validateOptions,appname,auth]

```