### PR TITLE
Throttle events based on Redis memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Notes:
 - The order of the oplog events is not guaranteed to be strictly chronological if there are multiple 
   workers per oplog
 
+## Requirements
+
+- Redis 3.2+
+
 ## Install
 
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -403,7 +403,7 @@ class MongoOplogReader {
           if (data.fromMigrate) return done(); // ignore shard balancing ops
           if (data.op === opCode.NOOP) return done(); // ignore informational no-operation
           this.processOp(data, replSetName, memberName)
-            .then(() => Promise.delay(this.throttleDelay))
+            .then(() => Promise.delay(this.throttleDelay * 1000))
             .then(() => done())
             .catch(err => done(err));
         }));


### PR DESCRIPTION
Events will be processed at full speed until redis memory usage is over 75%. Then it uses a linear backoff.